### PR TITLE
test: cover getUserId token validation

### DIFF
--- a/src/utils/get-user-id.ts
+++ b/src/utils/get-user-id.ts
@@ -1,0 +1,33 @@
+export interface AuthContext {
+    jwt: { verify(token: string): Promise<unknown> };
+    cookie: { jwt: { value?: string } };
+    set: { status?: number };
+}
+
+export const getUserId = async (
+    { jwt, cookie, set }: AuthContext,
+): Promise<string | undefined> => {
+    const token = cookie.jwt.value;
+
+    if (!token) {
+        set.status = 401;
+        return undefined;
+    }
+
+    try {
+        const payload = (await jwt.verify(token)) as {
+            userId: string;
+            exp?: number;
+        };
+
+        if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+            set.status = 401;
+            return undefined;
+        }
+
+        return payload.userId;
+    } catch {
+        set.status = 401;
+        return undefined;
+    }
+};

--- a/tests/getUserId.test.ts
+++ b/tests/getUserId.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "bun:test";
+import { SignJWT, jwtVerify } from "jose";
+import { getUserId } from "../src/utils/get-user-id";
+
+const secret = new TextEncoder().encode("secret");
+
+const jwt = {
+    verify: async (token: string) => {
+        const { payload } = await jwtVerify(token, secret);
+        return payload;
+    },
+};
+
+describe("getUserId", () => {
+    it("retorna undefined e status 401 para token expirado", async () => {
+        const token = await new SignJWT({ userId: "1" })
+            .setProtectedHeader({ alg: "HS256" })
+            .setExpirationTime(Math.floor(Date.now() / 1000) - 10)
+            .sign(secret);
+
+        const set: { status?: number } = {};
+        const cookie = { jwt: { value: token } };
+
+        const userId = await getUserId({ jwt, cookie, set });
+
+        expect(userId).toBeUndefined();
+        expect(set.status).toBe(401);
+    });
+
+    it("retorna undefined e status 401 para token ausente", async () => {
+        const set: { status?: number } = {};
+        const cookie = { jwt: { value: undefined } };
+
+        const userId = await getUserId({ jwt, cookie, set });
+
+        expect(userId).toBeUndefined();
+        expect(set.status).toBe(401);
+    });
+
+    it("retorna undefined e status 401 para token inválido", async () => {
+        const set: { status?: number } = {};
+        const cookie = { jwt: { value: "invalid.token" } };
+
+        const userId = await getUserId({ jwt, cookie, set });
+
+        expect(userId).toBeUndefined();
+        expect(set.status).toBe(401);
+    });
+});


### PR DESCRIPTION
## Summary
- extract getUserId helper for easier testing
- add tests for expired, missing, and invalid tokens

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6896183a49008328953241e59ff8f981