### PR TITLE
docs: improve setup and routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,44 @@
 # Elysia with Bun runtime
 
 ## Getting Started
-To get started with this template, simply paste this command into your terminal:
-```bash
-bun create elysia ./elysia-example
-```
+1. **Install dependencies**
+   ```bash
+   bun install
+   ```
+2. **Start the database** (using Docker)
+   ```bash
+   docker compose up -d db
+   ```
+3. **Configure environment variables**
+   Create a `.env` file with:
+   ```bash
+   DATABASE_URL=postgres://todo_user:todo_password@localhost:5432/todo_db
+   JWT_SECRET=your_jwt_secret
+   COOKIE_SECRET=your_cookie_secret
+   PORT=3000 # optional
+   ```
+4. **Run the server**
+   ```bash
+   bun run dev
+   ```
+   The API will be available at http://localhost:3000.
 
-## Development
-To start the development server run:
+## Routes
+- `GET /health` – health check endpoint.
+- `POST /register` – create a new user.
+- `POST /login` – authenticate and receive a JWT cookie.
+- `POST /logout` – clear the authentication cookie.
+- `/todos` – CRUD operations for todos (`GET`, `POST`, `GET /:id`, `PUT /:id`, `DELETE /:id`).
+- `/users` – user management (`GET`, `GET /:id`, `PUT /:id`, `DELETE /:id`).
+
+## Running
+### Development
 ```bash
 bun run dev
 ```
 
-Open http://localhost:3000/ with your browser to see the result.
+### Production
+```bash
+bun src/index.ts
+```
+


### PR DESCRIPTION
## Summary
- replace template getting started section with detailed installation and environment setup instructions
- document main API routes and usage
- note how to run the server in development and production

## Testing
- `bun run test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689618340c488328837d810c0047a911