### PR TITLE
Add updated_at column to users table

### DIFF
--- a/drizzle/0001_third_demogoblin.sql
+++ b/drizzle/0001_third_demogoblin.sql
@@ -1,0 +1,15 @@
+DROP INDEX "users_email_idx";--> statement-breakpoint
+DROP INDEX "users_username_idx";--> statement-breakpoint
+DROP INDEX "todos_done_idx";--> statement-breakpoint
+DROP INDEX "todos_priority_idx";--> statement-breakpoint
+DROP INDEX "todos_user_done_idx";--> statement-breakpoint
+DROP INDEX "todos_user_id_idx";--> statement-breakpoint
+DROP INDEX "todos_user_priority_idx";--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "updated_at" timestamp DEFAULT now() NOT NULL;--> statement-breakpoint
+CREATE INDEX "users_email_idx" ON "users" USING btree ("email");--> statement-breakpoint
+CREATE INDEX "users_username_idx" ON "users" USING btree ("username");--> statement-breakpoint
+CREATE INDEX "todos_done_idx" ON "todos" USING btree ("done");--> statement-breakpoint
+CREATE INDEX "todos_priority_idx" ON "todos" USING btree ("priority");--> statement-breakpoint
+CREATE INDEX "todos_user_done_idx" ON "todos" USING btree ("user_id","done");--> statement-breakpoint
+CREATE INDEX "todos_user_id_idx" ON "todos" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "todos_user_priority_idx" ON "todos" USING btree ("user_id","priority");

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,278 @@
+{
+	"id": "1d309fc1-42fe-4abd-b9d7-bf6622909cb9",
+	"prevId": "00000000-0000-0000-0000-000000000000",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.todos": {
+			"name": "todos",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"priority": {
+					"name": "priority",
+					"type": "priority",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'low'"
+				},
+				"done": {
+					"name": "done",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"todos_user_id_idx": {
+					"name": "todos_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"todos_priority_idx": {
+					"name": "todos_priority_idx",
+					"columns": [
+						{
+							"expression": "priority",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"todos_done_idx": {
+					"name": "todos_done_idx",
+					"columns": [
+						{
+							"expression": "done",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"todos_user_done_idx": {
+					"name": "todos_user_done_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "done",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"todos_user_priority_idx": {
+					"name": "todos_user_priority_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "priority",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"todos_user_id_users_id_fk": {
+					"name": "todos_user_id_users_id_fk",
+					"tableFrom": "todos",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"username": {
+					"name": "username",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"salt": {
+					"name": "salt",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"users_email_idx": {
+					"name": "users_email_idx",
+					"columns": [
+						{
+							"expression": "email",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"users_username_idx": {
+					"name": "users_username_idx",
+					"columns": [
+						{
+							"expression": "username",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.priority": {
+			"name": "priority",
+			"schema": "public",
+			"values": ["low", "medium", "high"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,13 +1,20 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1754605714232,
-      "tag": "0000_premium_zemo",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1754605714232,
+			"tag": "0000_premium_zemo",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1754667199289,
+			"tag": "0001_third_demogoblin",
+			"breakpoints": true
+		}
+	]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,39 +1,87 @@
-import { pgTable, index, unique, varchar, text, timestamp, foreignKey, boolean, pgEnum } from "drizzle-orm/pg-core"
-import { sql } from "drizzle-orm"
+import {
+	boolean,
+	foreignKey,
+	index,
+	pgEnum,
+	pgTable,
+	text,
+	timestamp,
+	unique,
+	varchar,
+} from "drizzle-orm/pg-core";
 
-export const priority = pgEnum("priority", ['low', 'medium', 'high'])
+export const priority = pgEnum("priority", ["low", "medium", "high"]);
 
+export const users = pgTable(
+	"users",
+	{
+		id: varchar().primaryKey().notNull(),
+		username: varchar({ length: 255 }).notNull(),
+		email: varchar({ length: 255 }).notNull(),
+		password: text().notNull(),
+		salt: varchar({ length: 64 }).default("").notNull(),
+		createdAt: timestamp("created_at", { mode: "string" })
+			.defaultNow()
+			.notNull(),
+		updatedAt: timestamp("updated_at", { mode: "string" })
+			.defaultNow()
+			.notNull(),
+	},
+	(table) => [
+		index("users_email_idx").using(
+			"btree",
+			table.email.asc().nullsLast().op("text_ops"),
+		),
+		index("users_username_idx").using(
+			"btree",
+			table.username.asc().nullsLast().op("text_ops"),
+		),
+		unique("users_email_unique").on(table.email),
+	],
+);
 
-export const users = pgTable("users", {
-	id: varchar().primaryKey().notNull(),
-	username: varchar({ length: 255 }).notNull(),
-	email: varchar({ length: 255 }).notNull(),
-	password: text().notNull(),
-	salt: varchar({ length: 64 }).default(').notNull(),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	index("users_email_idx").using("btree", table.email.asc().nullsLast().op("text_ops")),
-	index("users_username_idx").using("btree", table.username.asc().nullsLast().op("text_ops")),
-	unique("users_email_unique").on(table.email),
-]);
-
-export const todos = pgTable("todos", {
-	id: varchar().primaryKey().notNull(),
-	userId: varchar("user_id").notNull(),
-	description: varchar({ length: 255 }).notNull(),
-	priority: priority().default('low').notNull(),
-	done: boolean().default(false).notNull(),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	index("todos_done_idx").using("btree", table.done.asc().nullsLast().op("bool_ops")),
-	index("todos_priority_idx").using("btree", table.priority.asc().nullsLast().op("enum_ops")),
-	index("todos_user_done_idx").using("btree", table.userId.asc().nullsLast().op("bool_ops"), table.done.asc().nullsLast().op("text_ops")),
-	index("todos_user_id_idx").using("btree", table.userId.asc().nullsLast().op("text_ops")),
-	index("todos_user_priority_idx").using("btree", table.userId.asc().nullsLast().op("text_ops"), table.priority.asc().nullsLast().op("enum_ops")),
-	foreignKey({
+export const todos = pgTable(
+	"todos",
+	{
+		id: varchar().primaryKey().notNull(),
+		userId: varchar("user_id").notNull(),
+		description: varchar({ length: 255 }).notNull(),
+		priority: priority().default("low").notNull(),
+		done: boolean().default(false).notNull(),
+		createdAt: timestamp("created_at", { mode: "string" })
+			.defaultNow()
+			.notNull(),
+		updatedAt: timestamp("updated_at", { mode: "string" })
+			.defaultNow()
+			.notNull(),
+	},
+	(table) => [
+		index("todos_done_idx").using(
+			"btree",
+			table.done.asc().nullsLast().op("bool_ops"),
+		),
+		index("todos_priority_idx").using(
+			"btree",
+			table.priority.asc().nullsLast().op("enum_ops"),
+		),
+		index("todos_user_done_idx").using(
+			"btree",
+			table.userId.asc().nullsLast().op("bool_ops"),
+			table.done.asc().nullsLast().op("text_ops"),
+		),
+		index("todos_user_id_idx").using(
+			"btree",
+			table.userId.asc().nullsLast().op("text_ops"),
+		),
+		index("todos_user_priority_idx").using(
+			"btree",
+			table.userId.asc().nullsLast().op("text_ops"),
+			table.priority.asc().nullsLast().op("enum_ops"),
+		),
+		foreignKey({
 			columns: [table.userId],
 			foreignColumns: [users.id],
-			name: "todos_user_id_users_id_fk"
+			name: "todos_user_id_users_id_fk",
 		}).onDelete("cascade"),
-]);
+	],
+);

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -13,7 +13,7 @@ export const usersTable = pgTable(
 		password: text("password").notNull(),
 		salt: varchar("salt", { length: 64 }).notNull().default(""),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
-		updatedAt: timestamp("created_at").defaultNow().notNull(),
+		updatedAt: timestamp("updated_at").defaultNow().notNull(),
 	},
 	(table) => [
 		index("users_email_idx").on(table.email),
@@ -26,7 +26,7 @@ export const usersTable = pgTable(
  * é uma relação de que cada usuário pode ter o ou mais todo
  */
 export const usersTableRelations = relations(usersTable, ({ many }) => ({
-    todos: many(todosTable),
+	todos: many(todosTable),
 }));
 
 export type User = typeof usersTable.$inferSelect;


### PR DESCRIPTION
## Summary
- track user updates with dedicated updated_at timestamp
- generate migration for new users.updated_at column

## Testing
- `npx drizzle-kit pull` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*
- `npx biome check src/db/schema/users.ts drizzle/schema.ts`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896182dce748328bfb3b70021e89ec6