### PR TITLE
Add CSRF token interceptor to API client

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,6 @@
-import axios from 'axios'
+import axios, { AxiosHeaders } from 'axios'
+
+import { getCookie } from '../utils/cookies'
 
 const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:3000',
@@ -6,6 +8,24 @@ const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+})
+
+apiClient.interceptors.request.use((config) => {
+  const method = config.method?.toLowerCase()
+  const shouldAttachToken = method && ['post', 'put', 'patch', 'delete'].includes(method)
+
+  if (shouldAttachToken) {
+    const csrfToken = getCookie('csrfToken')
+    if (csrfToken) {
+      if (config.headers instanceof AxiosHeaders) {
+        config.headers.set('x-csrf-token', csrfToken)
+      } else {
+        config.headers = { ...(config.headers ?? {}), 'x-csrf-token': csrfToken }
+      }
+    }
+  }
+
+  return config
 })
 
 export { apiClient }

--- a/frontend/src/utils/cookies.ts
+++ b/frontend/src/utils/cookies.ts
@@ -1,0 +1,18 @@
+export const getCookie = (name: string): string | undefined => {
+  if (typeof document === 'undefined' || !document.cookie) {
+    return undefined
+  }
+
+  const cookies = document.cookie.split('; ')
+
+  for (const cookie of cookies) {
+    const [cookieName, ...valueParts] = cookie.split('=')
+    if (decodeURIComponent(cookieName) === name) {
+      return decodeURIComponent(valueParts.join('='))
+    }
+  }
+
+  return undefined
+}
+
+export const getCsrfToken = (): string | undefined => getCookie('csrfToken')


### PR DESCRIPTION
## Summary
- add a cookie utility that can fetch the csrfToken value
- attach the x-csrf-token header on mutating API requests via an axios interceptor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf9f83dd8c8328a93a85e9cebcdd49